### PR TITLE
Pass request object to check_credentials()

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ from aiohttp_basicauth import BasicAuthMiddleware
 
 
 class CustomBasicAuth(BasicAuthMiddleware):
-    async def check_credentials(self, username, password):
+    async def check_credentials(self, username, password, request):
         return username == 'user' and password == 'password'
 
 

--- a/aiohttp_basicauth/__init__.py
+++ b/aiohttp_basicauth/__init__.py
@@ -27,9 +27,9 @@ class BasicAuthMiddleware(object):
     async def authenticate(self, request):
         auth = self.parse_auth_header(request)
         return (auth is not None
-                and await self.check_credentials(auth.login, auth.password))
+                and await self.check_credentials(auth.login, auth.password, request))
 
-    async def check_credentials(self, username, password):
+    async def check_credentials(self, username, password, request):
         if username is None:
             raise ValueError('username is None')  # pragma: no cover
 
@@ -40,6 +40,7 @@ class BasicAuthMiddleware(object):
 
     def challenge(self):
         return web.Response(
+
             body=b'', status=401, reason='UNAUTHORIZED',
             headers={
                 hdrs.WWW_AUTHENTICATE: 'Basic realm="%s"' % self.realm,

--- a/aiohttp_basicauth/__init__.py
+++ b/aiohttp_basicauth/__init__.py
@@ -27,7 +27,8 @@ class BasicAuthMiddleware(object):
     async def authenticate(self, request):
         auth = self.parse_auth_header(request)
         return (auth is not None
-                and await self.check_credentials(auth.login, auth.password, request))
+                and await self.check_credentials(auth.login, auth.password,
+                                                 request))
 
     async def check_credentials(self, username, password, request):
         if username is None:

--- a/aiohttp_basicauth/__init__.py
+++ b/aiohttp_basicauth/__init__.py
@@ -40,7 +40,6 @@ class BasicAuthMiddleware(object):
 
     def challenge(self):
         return web.Response(
-
             body=b'', status=401, reason='UNAUTHORIZED',
             headers={
                 hdrs.WWW_AUTHENTICATE: 'Basic realm="%s"' % self.realm,


### PR DESCRIPTION
This pull request introduces a change to pass the `request` object to `check_credentials()`. Version number has not been modified.